### PR TITLE
Fix 'ENABLED' value check

### DIFF
--- a/lambda_functions/notify_slack.py
+++ b/lambda_functions/notify_slack.py
@@ -9,7 +9,7 @@ CHANNEL = os.environ['CHANNEL']  # Slack channel to post message to
 
 def lambda_handler(event, context):
     message = event['message']
-    if ENABLED == 'True':
+    if ENABLED == 'true':
         post_message(message)
     return event
 


### PR DESCRIPTION
The CF template defines values 'true' or 'false', without the capital 'T'

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
